### PR TITLE
Add multiplayer WebSocket client and wire into user store

### DIFF
--- a/app/Components/Player/Aircraft.tsx
+++ b/app/Components/Player/Aircraft.tsx
@@ -2,14 +2,13 @@
 
 import { useGLTF } from '@react-three/drei';
 import { useEffect, useMemo, useRef } from 'react';
-// import { usePlayerController } from '@/Components/Player/PlayerController';
 import * as THREE from 'three';
 import { SHIPS } from '@/Constants';
 import { Shield } from '../Shield/Shield';
 import { Mine } from '../Weapons/useMines';
 import { EngineSound } from '../Audio/EngineSound';
 import { ExplosionHandle } from '../Particles/ExplosionParticles/ExplosionParticles';
-import { usePlayerSABController } from './PlayerSABController';
+import { usePlayerServerController } from './PlayerServerController';
 import { FBMParams } from '../LODTerrain/Planet/fbm';
 
 type AircraftProps = {
@@ -75,10 +74,10 @@ export default function Aircraft({
     }
   }, [startPosition, startQuaternion, aircraftRef, id]);
 
-  usePlayerSABController({
+  usePlayerServerController({
     fbmParams,
     planetSize,
-    id,
+    id: String(id),
     trackId,
     minePoolRef,
     explosionsRef,

--- a/app/Components/Player/PlayerServerController.tsx
+++ b/app/Components/Player/PlayerServerController.tsx
@@ -12,7 +12,7 @@ import { useSettingsStore } from '@/Controllers/Settings/useSettingsStore';
 import { useProjectiles } from '../Weapons/useProjectiles';
 import { checkOutOfBoundsSDF } from '@/Utils/SDF';
 import { ExplosionHandle } from '../Particles/ExplosionParticles/ExplosionParticles';
-import { FBMParams } from '@/Components/LODTerrain/Planet/fbm';
+import { FBMParams, terrainElevationFBM, terrainElevationRidged } from '@/Components/LODTerrain/Planet/fbm';
 import { useUserStore } from '@/Controllers/Users/useUserStore';
 import type { PhysicsUpdatePayload } from '@/Lib/multiplayer/MultiplayerClient';
 
@@ -138,17 +138,38 @@ export function usePlayerServerController({
   }).current;
 
   const terrainMaxHeight = fbmParams?.uMaxHeight ?? 10;
-  const minAllowedRadius = Math.max(planetSize + terrainMaxHeight + 2, 1);
+  const minSurfaceOffset = 10;
   const toServerPlayerSpeed = Math.max(25, playerSpeed * 50);
 
   const enforceOutsidePlanetSurface = (object: THREE.Object3D) => {
     const radialDistance = object.position.length();
-    if (radialDistance >= minAllowedRadius) return;
 
+    let nx = 0;
+    let ny = 1;
+    let nz = 0;
+
+    if (radialDistance > 0.00001) {
+      nx = object.position.x / radialDistance;
+      ny = object.position.y / radialDistance;
+      nz = object.position.z / radialDistance;
+    }
+
+    let terrainRadius = planetSize;
+    if (fbmParams) {
+      const elevation = fbmParams.useRidged
+        ? terrainElevationRidged([nx, ny, nz], fbmParams)
+        : terrainElevationFBM([nx, ny, nz], fbmParams);
+      terrainRadius += elevation * terrainMaxHeight;
+    }
+
+    const minAllowedRadius = Math.max(terrainRadius + minSurfaceOffset, 1);
+    
     if (radialDistance <= 0.00001) {
       object.position.set(0, minAllowedRadius, 0);
       return;
     }
+
+    if (radialDistance >= minAllowedRadius) return;
 
     object.position.normalize().multiplyScalar(minAllowedRadius);
   };
@@ -209,7 +230,7 @@ export function usePlayerServerController({
   useEffect(() => {
     if (!aircraftRef.current) return;
     enforceOutsidePlanetSurface(aircraftRef.current);
-  }, [aircraftRef, minAllowedRadius]);
+  }, [aircraftRef, fbmParams, planetSize, terrainMaxHeight]);
 
   useEffect(() => {
     if (!multiplayerClient) return;

--- a/app/Components/Player/PlayerServerController.tsx
+++ b/app/Components/Player/PlayerServerController.tsx
@@ -12,7 +12,7 @@ import { useSettingsStore } from '@/Controllers/Settings/useSettingsStore';
 import { useProjectiles } from '../Weapons/useProjectiles';
 import { checkOutOfBoundsSDF } from '@/Utils/SDF';
 import { ExplosionHandle } from '../Particles/ExplosionParticles/ExplosionParticles';
-import { FBMParams, terrainElevationFBM, terrainElevationRidged } from '@/Components/LODTerrain/Planet/fbm';
+import { FBMParams } from '@/Components/LODTerrain/Planet/fbm';
 import { useUserStore } from '@/Controllers/Users/useUserStore';
 import type { PhysicsUpdatePayload } from '@/Lib/multiplayer/MultiplayerClient';
 
@@ -108,8 +108,6 @@ export function usePlayerServerController({
   pitchVelocity = 3,
   rollVelocity = 6,
   damping = 0.998,
-  fbmParams,
-  planetSize = 350,
 }: PlayerSystemOptions) {
   const {
     playerSpeed,
@@ -136,43 +134,6 @@ export function usePlayerServerController({
     interpQuat: new THREE.Quaternion(),
     velocity: new THREE.Vector3(),
   }).current;
-
-  const terrainMaxHeight = fbmParams?.uMaxHeight ?? 10;
-  const minSurfaceOffset = 10;
-  const toServerPlayerSpeed = Math.max(25, playerSpeed * 50);
-
-  const enforceOutsidePlanetSurface = (object: THREE.Object3D) => {
-    const radialDistance = object.position.length();
-
-    let nx = 0;
-    let ny = 1;
-    let nz = 0;
-
-    if (radialDistance > 0.00001) {
-      nx = object.position.x / radialDistance;
-      ny = object.position.y / radialDistance;
-      nz = object.position.z / radialDistance;
-    }
-
-    let terrainRadius = planetSize;
-    if (fbmParams) {
-      const elevation = fbmParams.useRidged
-        ? terrainElevationRidged([nx, ny, nz], fbmParams)
-        : terrainElevationFBM([nx, ny, nz], fbmParams);
-      terrainRadius += elevation * terrainMaxHeight;
-    }
-
-    const minAllowedRadius = Math.max(terrainRadius + minSurfaceOffset, 1);
-    
-    if (radialDistance <= 0.00001) {
-      object.position.set(0, minAllowedRadius, 0);
-      return;
-    }
-
-    if (radialDistance >= minAllowedRadius) return;
-
-    object.position.normalize().multiplyScalar(minAllowedRadius);
-  };
 
   const aircraftObjectRef = aircraftRef as React.RefObject<THREE.Object3D>;
   const explosionHandleRef = explosionsRef as React.RefObject<ExplosionHandle>;
@@ -203,7 +164,7 @@ export function usePlayerServerController({
       pitchVelocity,
       rollVelocity,
       damping,
-      playerSpeed: toServerPlayerSpeed,
+      playerSpeed,
       invertPitch: invertPitch ? -1 : 1,
       curvePoints: curve.getPoints(200).map((p) => [p.x, p.y, p.z]),
     });
@@ -214,7 +175,7 @@ export function usePlayerServerController({
     invertPitch,
     multiplayerClient,
     pitchVelocity,
-    toServerPlayerSpeed,
+    playerSpeed,
     rollVelocity,
   ]);
 
@@ -222,15 +183,10 @@ export function usePlayerServerController({
     if (!multiplayerClient) return;
 
     multiplayerClient.send('config', {
-      playerSpeed: toServerPlayerSpeed,
+      playerSpeed,
       invertPitch: invertPitch ? -1 : 1,
     });
-  }, [invertPitch, multiplayerClient, toServerPlayerSpeed]);
-
-  useEffect(() => {
-    if (!aircraftRef.current) return;
-    enforceOutsidePlanetSurface(aircraftRef.current);
-  }, [aircraftRef, fbmParams, planetSize, terrainMaxHeight]);
+  }, [invertPitch, multiplayerClient, playerSpeed]);
 
   useEffect(() => {
     if (!multiplayerClient) return;
@@ -455,8 +411,6 @@ export function usePlayerServerController({
         }
         ship.quaternion.copy(s.quat);
       }
-
-      enforceOutsidePlanetSurface(ship);
     }
 
     if (playingFieldRef?.current) {

--- a/app/Components/Player/PlayerServerController.tsx
+++ b/app/Components/Player/PlayerServerController.tsx
@@ -108,6 +108,8 @@ export function usePlayerServerController({
   pitchVelocity = 3,
   rollVelocity = 6,
   damping = 0.998,
+  fbmParams,
+  planetSize = 350,
 }: PlayerSystemOptions) {
   const {
     playerSpeed,
@@ -134,6 +136,22 @@ export function usePlayerServerController({
     interpQuat: new THREE.Quaternion(),
     velocity: new THREE.Vector3(),
   }).current;
+
+  const terrainMaxHeight = fbmParams?.uMaxHeight ?? 10;
+  const minAllowedRadius = Math.max(planetSize + terrainMaxHeight + 2, 1);
+  const toServerPlayerSpeed = Math.max(25, playerSpeed * 50);
+
+  const enforceOutsidePlanetSurface = (object: THREE.Object3D) => {
+    const radialDistance = object.position.length();
+    if (radialDistance >= minAllowedRadius) return;
+
+    if (radialDistance <= 0.00001) {
+      object.position.set(0, minAllowedRadius, 0);
+      return;
+    }
+
+    object.position.normalize().multiplyScalar(minAllowedRadius);
+  };
 
   const aircraftObjectRef = aircraftRef as React.RefObject<THREE.Object3D>;
   const explosionHandleRef = explosionsRef as React.RefObject<ExplosionHandle>;
@@ -164,7 +182,7 @@ export function usePlayerServerController({
       pitchVelocity,
       rollVelocity,
       damping,
-      playerSpeed,
+      playerSpeed: toServerPlayerSpeed,
       invertPitch: invertPitch ? -1 : 1,
       curvePoints: curve.getPoints(200).map((p) => [p.x, p.y, p.z]),
     });
@@ -175,7 +193,7 @@ export function usePlayerServerController({
     invertPitch,
     multiplayerClient,
     pitchVelocity,
-    playerSpeed,
+    toServerPlayerSpeed,
     rollVelocity,
   ]);
 
@@ -183,10 +201,15 @@ export function usePlayerServerController({
     if (!multiplayerClient) return;
 
     multiplayerClient.send('config', {
-      playerSpeed,
+      playerSpeed: toServerPlayerSpeed,
       invertPitch: invertPitch ? -1 : 1,
     });
-  }, [invertPitch, multiplayerClient, playerSpeed]);
+  }, [invertPitch, multiplayerClient, toServerPlayerSpeed]);
+
+  useEffect(() => {
+    if (!aircraftRef.current) return;
+    enforceOutsidePlanetSurface(aircraftRef.current);
+  }, [aircraftRef, minAllowedRadius]);
 
   useEffect(() => {
     if (!multiplayerClient) return;
@@ -411,6 +434,8 @@ export function usePlayerServerController({
         }
         ship.quaternion.copy(s.quat);
       }
+
+      enforceOutsidePlanetSurface(ship);
     }
 
     if (playingFieldRef?.current) {

--- a/app/Components/Player/PlayerServerController.tsx
+++ b/app/Components/Player/PlayerServerController.tsx
@@ -1,0 +1,443 @@
+'use client';
+
+import * as THREE from 'three';
+import { useEffect, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useGameStore } from '@/Controllers/Game/GameController';
+import { Mine, useMines } from '../Weapons/useMines';
+import { useProjectileCollisions } from '@/Controllers/Collision/useProjectileCollisions';
+import { onBulletCollision } from '@/Utils/collisions';
+import { TUBE_RADIUS } from '@/Constants';
+import { useSettingsStore } from '@/Controllers/Settings/useSettingsStore';
+import { useProjectiles } from '../Weapons/useProjectiles';
+import { checkOutOfBoundsSDF } from '@/Utils/SDF';
+import { ExplosionHandle } from '../Particles/ExplosionParticles/ExplosionParticles';
+import { FBMParams } from '@/Components/LODTerrain/Planet/fbm';
+import { useUserStore } from '@/Controllers/Users/useUserStore';
+import type { PhysicsUpdatePayload } from '@/Lib/multiplayer/MultiplayerClient';
+
+function catmullRom(
+  p0: THREE.Vector3,
+  p1: THREE.Vector3,
+  p2: THREE.Vector3,
+  p3: THREE.Vector3,
+  t: number,
+  out: THREE.Vector3,
+) {
+  const t2 = t * t;
+  const t3 = t2 * t;
+
+  out.set(
+    0.5 *
+      ((2 * p1.x) +
+        (-p0.x + p2.x) * t +
+        (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 +
+        (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3),
+    0.5 *
+      ((2 * p1.y) +
+        (-p0.y + p2.y) * t +
+        (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 +
+        (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3),
+    0.5 *
+      ((2 * p1.z) +
+        (-p0.z + p2.z) * t +
+        (2 * p0.z - 5 * p1.z + 4 * p2.z - p3.z) * t2 +
+        (-p0.z + 3 * p1.z - 3 * p2.z + p3.z) * t3),
+  );
+
+  return out;
+}
+
+function clamp(val: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, val));
+}
+
+const INTERPOLATION_TIME = 100;
+const GAMEPAD_POLL_FRAMES = 5;
+
+const inputAxisRef = { current: { x: 0, y: 0 } };
+const throttleRef = { current: 0 };
+const firingRef = { current: false };
+
+export const playerInputAxis = {
+  set: (axis: { x: number; y: number }) => {
+    inputAxisRef.current = axis;
+  },
+};
+
+export const setThrottle = (value: number) => {
+  throttleRef.current = value;
+};
+
+export const setFiringRef = (value: boolean) => {
+  firingRef.current = value;
+};
+
+type PlayerSystemOptions = {
+  id: string;
+  trackId: number;
+  minePoolRef: React.RefObject<Mine[]>;
+  explosionsRef?: React.RefObject<ExplosionHandle>;
+  aircraftRef: React.RefObject<THREE.Group | null>;
+  playerRefs: React.RefObject<THREE.Group | null>[];
+  obstacleRefs?: React.RefObject<THREE.Mesh | null>[];
+  playingFieldRef?: React.RefObject<THREE.Mesh | null>;
+  fbmParams?: FBMParams;
+  planetSize?: number;
+  pitchVelocity?: number;
+  rollVelocity?: number;
+  acceleration?: number;
+  damping?: number;
+  noiseAmplitude?: number;
+  noiseFrequency?: number;
+  botSpeed: number;
+  enabled: boolean;
+  onSpeedChange?: (speed: number) => void;
+  onAcceleratingChange?: (state: boolean) => void;
+  onBrakingChange?: (state: boolean) => void;
+};
+
+export function usePlayerServerController({
+  id: playerId,
+  minePoolRef,
+  explosionsRef,
+  aircraftRef,
+  playerRefs,
+  playingFieldRef,
+  acceleration = 10,
+  pitchVelocity = 3,
+  rollVelocity = 6,
+  damping = 0.998,
+}: PlayerSystemOptions) {
+  const {
+    playerSpeed,
+    raceData,
+    setOutOfBounds,
+    addOutOfBoundsTime,
+    track: curve,
+  } = useGameStore((s) => s);
+  const { invertPitch } = useSettingsStore((s) => s);
+  const multiplayerClient = useUserStore((s) => s.multiplayerClient);
+
+  const keys = useRef<Record<string, boolean>>({});
+  const gamepadIndex = useRef<number | null>(null);
+
+  const serverStates = useRef<
+    Array<{ time: number; pos: THREE.Vector3; quat: THREE.Quaternion; velocity?: THREE.Vector3 }>
+  >([]);
+
+  const gamepadPollCounterRef = useRef(0);
+  const smoothedCameraTargetRef = useRef<THREE.Object3D>(new THREE.Object3D());
+
+  const tmp = useRef({
+    interpPos: new THREE.Vector3(),
+    interpQuat: new THREE.Quaternion(),
+    velocity: new THREE.Vector3(),
+  }).current;
+
+  const aircraftObjectRef = aircraftRef as React.RefObject<THREE.Object3D>;
+  const explosionHandleRef = explosionsRef as React.RefObject<ExplosionHandle>;
+
+  const { fire, poolRef: projectilePoolRef } = useProjectiles(aircraftObjectRef, explosionHandleRef, {
+    fireRate: 5,
+    maxProjectiles: 20,
+    velocity: 400,
+  });
+
+  const { drop } = useMines(aircraftObjectRef, minePoolRef, explosionHandleRef, {
+    maxMines: 16,
+    dropOffset: 6,
+  });
+
+  useProjectileCollisions({
+    projectiles: projectilePoolRef.current,
+    playerRefs,
+    explosionsRef: explosionHandleRef,
+    onCollide: onBulletCollision,
+  });
+
+  useEffect(() => {
+    if (!multiplayerClient) return;
+
+    multiplayerClient.send('config', {
+      acceleration,
+      pitchVelocity,
+      rollVelocity,
+      damping,
+      playerSpeed,
+      invertPitch: invertPitch ? -1 : 1,
+      curvePoints: curve.getPoints(200).map((p) => [p.x, p.y, p.z]),
+    });
+  }, [
+    acceleration,
+    curve,
+    damping,
+    invertPitch,
+    multiplayerClient,
+    pitchVelocity,
+    playerSpeed,
+    rollVelocity,
+  ]);
+
+  useEffect(() => {
+    if (!multiplayerClient) return;
+
+    multiplayerClient.send('config', {
+      playerSpeed,
+      invertPitch: invertPitch ? -1 : 1,
+    });
+  }, [invertPitch, multiplayerClient, playerSpeed]);
+
+  useEffect(() => {
+    if (!multiplayerClient) return;
+
+    const interval = window.setInterval(() => {
+      multiplayerClient.send('input', {
+        throttle: throttleRef.current,
+        inputAxis: inputAxisRef.current,
+      });
+    }, 33);
+
+    return () => window.clearInterval(interval);
+  }, [multiplayerClient]);
+
+  useEffect(() => {
+    const client = multiplayerClient;
+    const MOVEMENT_KEYS = ['a', 'd', 'w', 's'];
+    const THROTTLE_KEYS = ['i', 'k'];
+    const ALL_INPUT_KEYS = [...MOVEMENT_KEYS, ...THROTTLE_KEYS];
+
+    const calculateInput = (currentKeys: Record<string, boolean>) => {
+      let rollInput = 0;
+      let pitchInput = 0;
+
+      if (currentKeys.d) rollInput -= 1;
+      if (currentKeys.a) rollInput += 1;
+      if (currentKeys.w) pitchInput -= 1;
+      if (currentKeys.s) pitchInput += 1;
+
+      return {
+        x: clamp(rollInput, -1, 1),
+        y: clamp(pitchInput, -1, 1),
+      };
+    };
+
+    const calculateThrottle = (currentKeys: Record<string, boolean>) => {
+      if (currentKeys.i) return 1;
+      if (currentKeys.k) return -1;
+      return 0;
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+
+      if (ALL_INPUT_KEYS.includes(key) && !keys.current[key]) {
+        keys.current[key] = true;
+
+        if (client) {
+          const newInputAxis = calculateInput(keys.current);
+          const newThrottle = calculateThrottle(keys.current);
+
+          inputAxisRef.current = newInputAxis;
+          throttleRef.current = newThrottle;
+
+          client.send('input', {
+            throttle: newThrottle,
+            inputAxis: newInputAxis,
+          });
+        }
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+
+      if (ALL_INPUT_KEYS.includes(key) && keys.current[key]) {
+        keys.current[key] = false;
+
+        if (client) {
+          const newInputAxis = calculateInput(keys.current);
+          const newThrottle = calculateThrottle(keys.current);
+
+          inputAxisRef.current = newInputAxis;
+          throttleRef.current = newThrottle;
+
+          client.send('input', {
+            throttle: newThrottle,
+            inputAxis: newInputAxis,
+          });
+        }
+      }
+    };
+
+    const handleGamepadConnected = (e: GamepadEvent) => {
+      if (gamepadIndex.current === null) gamepadIndex.current = e.gamepad.index;
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('gamepadconnected', handleGamepadConnected);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('gamepadconnected', handleGamepadConnected);
+    };
+  }, [multiplayerClient]);
+
+  useEffect(() => {
+    if (!multiplayerClient) return;
+
+    const handlePhysicsUpdate = (payload: PhysicsUpdatePayload) => {
+      const localPlayerId = multiplayerClient.playerId;
+      if (!localPlayerId) return;
+
+      const newPhysicsState = payload.state[localPlayerId];
+      if (!newPhysicsState) return;
+
+      const [x, y, z] = newPhysicsState.pos;
+      const [qx, qy, qz, qw] = newPhysicsState.rot;
+      const time = Date.now();
+
+      const velocityArr = newPhysicsState.vel ?? newPhysicsState.velocity;
+      let velocityVec: THREE.Vector3 | undefined;
+
+      if (velocityArr && velocityArr.length >= 3) {
+        velocityVec = new THREE.Vector3(velocityArr[0], velocityArr[1], velocityArr[2]);
+      }
+
+      serverStates.current.push({
+        time,
+        pos: new THREE.Vector3(x, y, z),
+        quat: new THREE.Quaternion(qx, qy, qz, qw),
+        velocity: velocityVec,
+      });
+
+      if (serverStates.current.length > 20) {
+        serverStates.current.shift();
+      }
+    };
+
+    const unsubscribe = multiplayerClient.on<PhysicsUpdatePayload>('physics:update', handlePhysicsUpdate);
+
+    return () => {
+      unsubscribe();
+    };
+  }, [multiplayerClient]);
+
+  useFrame((_, delta) => {
+    const ship = aircraftRef.current;
+    if (!ship) return;
+
+    gamepadPollCounterRef.current = (gamepadPollCounterRef.current + 1) % GAMEPAD_POLL_FRAMES;
+
+    const keysState = keys.current;
+    const shouldFire = firingRef.current;
+
+    let gp: Gamepad | null | undefined;
+    if (gamepadPollCounterRef.current === 0 && typeof navigator.getGamepads === 'function') {
+      const gps = navigator.getGamepads();
+      gp = gamepadIndex.current !== null ? (gps?.[gamepadIndex.current] ?? undefined) : gps?.[0];
+    }
+
+    let rollInput = 0;
+    let pitchInput = 0;
+
+    const { x: touchX, y: touchY } = inputAxisRef.current;
+    if (Math.abs(touchX) > 0.01 || Math.abs(touchY) > 0.01) {
+      rollInput += touchX;
+      pitchInput += touchY;
+    } else {
+      if (gp?.connected) {
+        rollInput += gp.axes?.[0] ?? 0;
+        pitchInput += gp.axes?.[1] ?? 0;
+      }
+      if (keysState.a) rollInput -= 1;
+      if (keysState.d) rollInput += 1;
+      if (keysState.w) pitchInput -= 1;
+      if (keysState.s) pitchInput += 1;
+    }
+
+    rollInput = clamp(rollInput, -1, 1);
+    pitchInput = clamp(pitchInput, -1, 1);
+
+    let throttleInput = 0;
+    if (keysState.i) throttleInput = 1;
+    else if (keysState.k) throttleInput = -1;
+
+    inputAxisRef.current = { x: rollInput, y: pitchInput };
+    throttleRef.current = throttleInput;
+
+    const numericPlayerId = Number(playerId);
+    const cannonValue = raceData[numericPlayerId]?.cannonValue || 0;
+    const useMine = raceData[numericPlayerId]?.useMine;
+
+    if ((keysState.j || shouldFire) && cannonValue > 0) fire(numericPlayerId);
+    if ((keysState.j || shouldFire) && useMine) drop();
+
+    if (serverStates.current.length > 0) {
+      const targetTime = Date.now() - INTERPOLATION_TIME;
+
+      while (serverStates.current.length > 1 && serverStates.current[1].time <= targetTime) {
+        serverStates.current.shift();
+      }
+
+      const buf = serverStates.current;
+
+      if (buf.length >= 3) {
+        const s0 = buf[0];
+        const s1 = buf[1];
+
+        const denom = s1.time - s0.time;
+        const t = denom > 0 ? clamp((targetTime - s0.time) / denom, 0, 1) : 0;
+
+        const sMinus1 = buf[0];
+        const sPlus2 = buf[2];
+
+        catmullRom(sMinus1.pos, s0.pos, s1.pos, sPlus2.pos, t, tmp.interpPos);
+        tmp.interpQuat.copy(s0.quat).slerp(s1.quat, t);
+
+        ship.position.copy(tmp.interpPos);
+        ship.quaternion.copy(tmp.interpQuat);
+      } else {
+        const s = buf[0];
+        const deltaExtrap = (Date.now() - s.time) / 1000;
+
+        if (s.velocity) {
+          tmp.interpPos.copy(s.pos).add(tmp.velocity.copy(s.velocity).multiplyScalar(deltaExtrap));
+          ship.position.copy(tmp.interpPos);
+        } else {
+          ship.position.copy(s.pos);
+        }
+        ship.quaternion.copy(s.quat);
+      }
+    }
+
+    if (playingFieldRef?.current) {
+      checkOutOfBoundsSDF(
+        ship,
+        curve,
+        TUBE_RADIUS,
+        [{ t: 0.4, radius: 100 }],
+        Number(playerId),
+        delta,
+        raceData,
+        setOutOfBounds,
+        addOutOfBoundsTime,
+      );
+    }
+
+    const cameraTarget = smoothedCameraTargetRef.current;
+    const cameraPositionLag = 0.15;
+    const cameraRotationLag = 0.1;
+
+    const positionAlpha = 1 - Math.exp(-delta / cameraPositionLag);
+    const rotationAlpha = 1 - Math.exp(-delta / cameraRotationLag);
+
+    cameraTarget.position.lerp(ship.position, positionAlpha);
+    cameraTarget.quaternion.slerp(ship.quaternion, rotationAlpha);
+    ship.userData.smoothedCameraTarget = cameraTarget;
+
+    if (ship.userData.recordSimulationState) ship.userData.recordSimulationState();
+  });
+}

--- a/app/Components/UI/TouchControls/ControlButtons.tsx
+++ b/app/Components/UI/TouchControls/ControlButtons.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { setThrottle, setFiringRef } from '@/Components/Player/PlayerController'; // keep your function
+import { setThrottle, setFiringRef } from '@/Components/Player/PlayerServerController'; // keep your function
 import { isMobileDevice } from '@/Utils';
 import './ThrottleBtn.css';
 

--- a/app/Components/UI/TouchControls/RadialTouchInput.tsx
+++ b/app/Components/UI/TouchControls/RadialTouchInput.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react';
 import { isMobileDevice } from '@/Utils';
-import { playerInputAxis } from '@/Components/Player/PlayerController';
+import { playerInputAxis } from '@/Components/Player/PlayerServerController';
 import './RadialTouchInput.css';
 
 interface Props {

--- a/app/Components/UI/TouchControls/Throttle.tsx
+++ b/app/Components/UI/TouchControls/Throttle.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, CSSProperties } from 'react';
-import { setThrottle } from '@/Components/Player/PlayerController'; // Adjust path if needed
+import { setThrottle } from '@/Components/Player/PlayerServerController'; // Adjust path if needed
 import { isMobileDevice } from '@/Utils';
 
 export function ThrottleLever() {

--- a/app/Components/UI/TouchControls/TouchController.tsx
+++ b/app/Components/UI/TouchControls/TouchController.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { Joystick } from 'react-joystick-component';
 import { isMobileDevice } from '@/Utils';
-import { playerInputAxis } from '@/Components/Player/PlayerController';
+import { playerInputAxis } from '@/Components/Player/PlayerServerController';
 import './TouchControlls.css';
 
 export default function TouchControls() {

--- a/app/Controllers/Users/useUserStore.tsx
+++ b/app/Controllers/Users/useUserStore.tsx
@@ -4,6 +4,7 @@
 import { create } from 'zustand';
 import { onAuthStateChanged, signOut, User as FirebaseUser } from 'firebase/auth';
 import { auth } from '@/Lib/Firebase';
+import { MultiplayerClient, type JoinPayload } from '@/Lib/multiplayer/MultiplayerClient';
 import type { User } from '@/Constants/types';
 import { useAlertStore } from '../Alert/useAlertStore';
 import { fetchWithAppCheck } from './useUser';
@@ -12,10 +13,14 @@ interface UserState {
   user: User | null;
   loading: boolean;
   error: string | null;
+  multiplayerClient: MultiplayerClient | null;
 
   setError: (error: string | null) => void;
 
   setUser: (user: User | null) => void;
+  setMultiplayerClient: (client: MultiplayerClient | null) => void;
+  connectMultiplayer: (joinPayload?: JoinPayload) => MultiplayerClient;
+  disconnectMultiplayer: () => void;
 
   fetchUserFromAPI: (uid: string) => Promise<User>;
   createUser: (newUser: User & { password?: string }) => Promise<{
@@ -33,9 +38,30 @@ export const useUserStore = create<UserState>((set, get) => ({
   user: null,
   loading: true,
   error: null,
+  multiplayerClient: null,
 
   setError: (error) => set({ error }),
   setUser: (user) => set({ user }),
+  setMultiplayerClient: (client) => set({ multiplayerClient: client }),
+
+  connectMultiplayer: (joinPayload = {}) => {
+    const existingClient = get().multiplayerClient;
+    if (existingClient) {
+      existingClient.connect(joinPayload);
+      return existingClient;
+    }
+
+    const newClient = new MultiplayerClient();
+    newClient.connect(joinPayload);
+    set({ multiplayerClient: newClient });
+    return newClient;
+  },
+
+  disconnectMultiplayer: () => {
+    const existingClient = get().multiplayerClient;
+    existingClient?.disconnect();
+    set({ multiplayerClient: null });
+  },
 
   // Fetch user from backend
   fetchUserFromAPI: async (uid: string) => {

--- a/app/Controllers/Users/useUserStore.tsx
+++ b/app/Controllers/Users/useUserStore.tsx
@@ -158,6 +158,7 @@ export const useUserStore = create<UserState>((set, get) => ({
   // Sign out
   signOutUser: async () => {
     try {
+      get().disconnectMultiplayer();
       await signOut(auth);
       set({ user: null, error: null });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -170,16 +171,22 @@ export const useUserStore = create<UserState>((set, get) => ({
 
 // Subscribe to Firebase auth changes once
 export function initUserStore() {
-  const { fetchUserFromAPI, setUser } = useUserStore.getState();
+  const { fetchUserFromAPI, setUser, connectMultiplayer, disconnectMultiplayer } = useUserStore.getState();
   onAuthStateChanged(auth, async (firebaseUser: FirebaseUser | null) => {
     if (firebaseUser) {
       if (!firebaseUser.emailVerified) {
+        disconnectMultiplayer();
         useAlertStore.getState().setAlert({
           type: 'error',
           message: 'Please verify your email before logging in.',
         });
         return;
       }
+
+      connectMultiplayer({
+        name: firebaseUser.displayName ?? firebaseUser.email ?? 'anon',
+      });
+
       try {
         await fetchUserFromAPI(firebaseUser.uid);
       } catch {
@@ -192,6 +199,7 @@ export function initUserStore() {
         });
       }
     } else {
+      disconnectMultiplayer();
       setUser(null);
     }
   });

--- a/app/Lib/multiplayer/MultiplayerClient.ts
+++ b/app/Lib/multiplayer/MultiplayerClient.ts
@@ -66,18 +66,41 @@ type OutboundMessage = {
   payload?: unknown;
 };
 
-function defaultMultiplayerWsUrl(): string {
-  if (typeof window === 'undefined') {
-    return 'ws://localhost:3030';
+const DEFAULT_MULTIPLAYER_SERVER_HTTP_URL = 'https://nebularaceserver.onrender.com';
+
+function normalizeWebSocketUrl(input: string): string {
+  if (input.startsWith('ws://') || input.startsWith('wss://')) {
+    return input;
   }
 
+  if (input.startsWith('http://')) {
+    return `ws://${input.slice('http://'.length)}`;
+  }
+
+  if (input.startsWith('https://')) {
+    return `wss://${input.slice('https://'.length)}`;
+  }
+
+  return input;
+}
+
+function defaultMultiplayerWsUrl(): string {
   if (process.env.NEXT_PUBLIC_MULTIPLAYER_WS_URL) {
-    return process.env.NEXT_PUBLIC_MULTIPLAYER_WS_URL;
+    return normalizeWebSocketUrl(process.env.NEXT_PUBLIC_MULTIPLAYER_WS_URL);
+  }
+
+  if (typeof window === 'undefined') {
+    return normalizeWebSocketUrl(DEFAULT_MULTIPLAYER_SERVER_HTTP_URL);
   }
 
   const isSecure = window.location.protocol === 'https:';
   const protocol = isSecure ? 'wss:' : 'ws:';
-  return `${protocol}//${window.location.hostname}:3030`;
+
+  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    return `${protocol}//${window.location.hostname}:3030`;
+  }
+
+  return normalizeWebSocketUrl(DEFAULT_MULTIPLAYER_SERVER_HTTP_URL);
 }
 
 export class MultiplayerClient {
@@ -105,7 +128,7 @@ export class MultiplayerClient {
   }
 
   constructor(config: MultiplayerClientConfig = {}) {
-    this.url = config.url ?? defaultMultiplayerWsUrl();
+    this.url = normalizeWebSocketUrl(config.url ?? defaultMultiplayerWsUrl());
     this.autoReconnect = config.autoReconnect ?? true;
     this.reconnectDelayMs = config.reconnectDelayMs ?? 1000;
   }

--- a/app/Lib/multiplayer/MultiplayerClient.ts
+++ b/app/Lib/multiplayer/MultiplayerClient.ts
@@ -95,6 +95,15 @@ export class MultiplayerClient {
   playerId: string | null = null;
   roomId: string | null = null;
 
+  private debugLog(message: string, meta?: Record<string, unknown>): void {
+    if (typeof console === 'undefined') return;
+    if (meta) {
+      console.info(`[MultiplayerClient] ${message}`, meta);
+      return;
+    }
+    console.info(`[MultiplayerClient] ${message}`);
+  }
+
   constructor(config: MultiplayerClientConfig = {}) {
     this.url = config.url ?? defaultMultiplayerWsUrl();
     this.autoReconnect = config.autoReconnect ?? true;
@@ -110,13 +119,18 @@ export class MultiplayerClient {
     this.lastJoinPayload = joinPayload;
 
     if (this.ws && this.isSocketOpenOrConnecting(this.ws)) {
+      this.debugLog('connect() skipped; socket already open/connecting', {
+        readyState: this.ws.readyState,
+      });
       return;
     }
 
+    this.debugLog('Opening websocket connection', { url: this.url });
     this.clearReconnectTimer();
     this.ws = new WebSocket(this.url);
 
     this.ws.onopen = () => {
+      this.debugLog('WebSocket connected', { url: this.url });
       this.send('join', this.lastJoinPayload ?? {});
       this.flushQueue();
       this.emit('open', undefined);
@@ -150,13 +164,20 @@ export class MultiplayerClient {
     };
 
     this.ws.onerror = (error) => {
+      this.debugLog('WebSocket error emitted');
       this.emit('error', error);
     };
 
-    this.ws.onclose = () => {
+    this.ws.onclose = (event) => {
+      this.debugLog('WebSocket disconnected', {
+        code: event.code,
+        reason: event.reason || 'no reason provided',
+        wasClean: event.wasClean,
+      });
       this.emit('close', undefined);
 
       if (this.autoReconnect && !this.manuallyDisconnected) {
+        this.debugLog('Scheduling websocket reconnect', { delayMs: this.reconnectDelayMs });
         this.reconnectTimer = setTimeout(() => {
           this.connect(this.lastJoinPayload ?? {});
         }, this.reconnectDelayMs);
@@ -165,14 +186,19 @@ export class MultiplayerClient {
   }
 
   disconnect(): void {
+    this.debugLog('Disconnect requested by client');
     this.manuallyDisconnected = true;
     this.clearReconnectTimer();
     const socket = this.ws;
     this.ws = null;
 
     if (socket && this.isSocketOpenOrConnecting(socket)) {
+      this.debugLog('Closing websocket connection', { readyState: socket.readyState });
       socket.close(1000, 'Client disconnect');
+      return;
     }
+
+    this.debugLog('No websocket to close during disconnect');
   }
 
   send(type: string, payload?: unknown): void {

--- a/app/Lib/multiplayer/MultiplayerClient.ts
+++ b/app/Lib/multiplayer/MultiplayerClient.ts
@@ -1,0 +1,243 @@
+'use client';
+
+export type PhysicsPlayerState = {
+  pos: [number, number, number];
+  rot: [number, number, number, number];
+  velocity?: [number, number, number];
+  vel?: [number, number, number];
+};
+
+export type PhysicsUpdatePayload = {
+  state: Record<string, PhysicsPlayerState>;
+};
+
+export type MultiplayerMessagePayloads = {
+  connected: { playerId: string };
+  joined: {
+    playerId: string;
+    roomId: string;
+    fbmParams?: Record<string, unknown>;
+    curvePoints?: number[][];
+  };
+  removed: { playerId: string };
+  'room:update': {
+    phase: string;
+    players: Array<{
+      id: string;
+      name: string;
+      position: number | null;
+      score: number;
+      outOfBoundsTime: number;
+      ready: boolean;
+    }>;
+  };
+  'pregame:tick': { seconds: number };
+  'racecountdown:tick': { seconds: number };
+  'race:start': { startedAt: number };
+  'race:end': Record<string, never>;
+  'player:finished': { id: string; finishedAt: number };
+  'physics:update': PhysicsUpdatePayload;
+  input: {
+    playerId: string;
+    throttle?: number;
+    inputAxis?: { x: number; y: number };
+  };
+  'server:log': { message: string };
+};
+
+export type MultiplayerEventType = keyof MultiplayerMessagePayloads | string;
+
+export type MultiplayerClientConfig = {
+  url?: string;
+  autoReconnect?: boolean;
+  reconnectDelayMs?: number;
+};
+
+export type JoinPayload = {
+  name?: string;
+  fbmParams?: Record<string, unknown>;
+  curvePoints?: number[][];
+};
+
+type Listener<T = unknown> = (payload: T) => void;
+
+type OutboundMessage = {
+  type: string;
+  payload?: unknown;
+};
+
+function defaultMultiplayerWsUrl(): string {
+  if (typeof window === 'undefined') {
+    return 'ws://localhost:3030';
+  }
+
+  if (process.env.NEXT_PUBLIC_MULTIPLAYER_WS_URL) {
+    return process.env.NEXT_PUBLIC_MULTIPLAYER_WS_URL;
+  }
+
+  const isSecure = window.location.protocol === 'https:';
+  const protocol = isSecure ? 'wss:' : 'ws:';
+  return `${protocol}//${window.location.hostname}:3030`;
+}
+
+export class MultiplayerClient {
+  private ws: WebSocket | null = null;
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private readonly queue: OutboundMessage[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastJoinPayload: JoinPayload | null = null;
+  private manuallyDisconnected = false;
+
+  private readonly url: string;
+  private readonly autoReconnect: boolean;
+  private readonly reconnectDelayMs: number;
+
+  playerId: string | null = null;
+  roomId: string | null = null;
+
+  constructor(config: MultiplayerClientConfig = {}) {
+    this.url = config.url ?? defaultMultiplayerWsUrl();
+    this.autoReconnect = config.autoReconnect ?? true;
+    this.reconnectDelayMs = config.reconnectDelayMs ?? 1000;
+  }
+
+  get isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  connect(joinPayload: JoinPayload = {}): void {
+    this.manuallyDisconnected = false;
+    this.lastJoinPayload = joinPayload;
+
+    if (this.ws && [WebSocket.OPEN, WebSocket.CONNECTING].includes(this.ws.readyState)) {
+      return;
+    }
+
+    this.clearReconnectTimer();
+    this.ws = new WebSocket(this.url);
+
+    this.ws.onopen = () => {
+      this.send('join', this.lastJoinPayload ?? {});
+      this.flushQueue();
+      this.emit('open', undefined);
+    };
+
+    this.ws.onmessage = (event) => {
+      let data: { type?: string; payload?: unknown };
+
+      try {
+        data = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      if (!data?.type) {
+        return;
+      }
+
+      if (data.type === 'connected') {
+        const payload = data.payload as MultiplayerMessagePayloads['connected'];
+        this.playerId = payload.playerId;
+      }
+
+      if (data.type === 'joined') {
+        const payload = data.payload as MultiplayerMessagePayloads['joined'];
+        this.playerId = payload.playerId;
+        this.roomId = payload.roomId;
+      }
+
+      this.emit(data.type, data.payload);
+    };
+
+    this.ws.onerror = (error) => {
+      this.emit('error', error);
+    };
+
+    this.ws.onclose = () => {
+      this.emit('close', undefined);
+
+      if (this.autoReconnect && !this.manuallyDisconnected) {
+        this.reconnectTimer = setTimeout(() => {
+          this.connect(this.lastJoinPayload ?? {});
+        }, this.reconnectDelayMs);
+      }
+    };
+  }
+
+  disconnect(): void {
+    this.manuallyDisconnected = true;
+    this.clearReconnectTimer();
+    const socket = this.ws;
+    this.ws = null;
+
+    if (socket && [WebSocket.OPEN, WebSocket.CONNECTING].includes(socket.readyState)) {
+      socket.close(1000, 'Client disconnect');
+    }
+  }
+
+  send(type: string, payload?: unknown): void {
+    const message: OutboundMessage = { type, payload };
+
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.queue.push(message);
+      return;
+    }
+
+    this.ws.send(JSON.stringify(message));
+  }
+
+  on<T = unknown>(type: MultiplayerEventType, listener: Listener<T>): () => void {
+    const key = String(type);
+    if (!this.listeners.has(key)) {
+      this.listeners.set(key, new Set());
+    }
+
+    const set = this.listeners.get(key);
+    if (!set) {
+      return () => undefined;
+    }
+
+    set.add(listener as Listener);
+    return () => this.off(key, listener as Listener);
+  }
+
+  off(type: MultiplayerEventType, listener: Listener): void {
+    const key = String(type);
+    const set = this.listeners.get(key);
+    if (!set) {
+      return;
+    }
+
+    set.delete(listener);
+    if (set.size === 0) {
+      this.listeners.delete(key);
+    }
+  }
+
+  private emit(type: string, payload: unknown): void {
+    const listeners = this.listeners.get(type);
+    if (!listeners || listeners.size === 0) {
+      return;
+    }
+
+    listeners.forEach((listener) => listener(payload));
+  }
+
+  private flushQueue(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    while (this.queue.length > 0) {
+      const message = this.queue.shift();
+      if (!message) continue;
+      this.ws.send(JSON.stringify(message));
+    }
+  }
+
+  private clearReconnectTimer(): void {
+    if (!this.reconnectTimer) return;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
+}

--- a/app/Lib/multiplayer/MultiplayerClient.ts
+++ b/app/Lib/multiplayer/MultiplayerClient.ts
@@ -109,7 +109,7 @@ export class MultiplayerClient {
     this.manuallyDisconnected = false;
     this.lastJoinPayload = joinPayload;
 
-    if (this.ws && [WebSocket.OPEN, WebSocket.CONNECTING].includes(this.ws.readyState)) {
+    if (this.ws && this.isSocketOpenOrConnecting(this.ws)) {
       return;
     }
 
@@ -170,7 +170,7 @@ export class MultiplayerClient {
     const socket = this.ws;
     this.ws = null;
 
-    if (socket && [WebSocket.OPEN, WebSocket.CONNECTING].includes(socket.readyState)) {
+    if (socket && this.isSocketOpenOrConnecting(socket)) {
       socket.close(1000, 'Client disconnect');
     }
   }
@@ -235,6 +235,10 @@ export class MultiplayerClient {
     }
   }
 
+
+  private isSocketOpenOrConnecting(socket: WebSocket): boolean {
+    return socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING;
+  }
   private clearReconnectTimer(): void {
     if (!this.reconnectTimer) return;
     clearTimeout(this.reconnectTimer);

--- a/app/stages/stage1/page.tsx
+++ b/app/stages/stage1/page.tsx
@@ -135,7 +135,7 @@ const Scene = React.memo(function Scene({
           playingFieldRef={playingFieldRef}
           startPosition={startPositions[0].position as [number, number, number]}
           startQuaternion={startPositions[0].quaternion}
-          acceleration={0.1}
+          acceleration={200}
           damping={0.99}
           botSpeed={2}
         />


### PR DESCRIPTION
### Motivation
- Provide a client-side bridge so the frontend PlayerServerController can send/receive multiplayer messages to the new Node.js multiplayer server and server-side physics workers.
- Persist a reusable multiplayer session instance in app state so UI/components can share a single socket and lifecycle helpers.

### Description
- Added a new `MultiplayerClient` in `app/Lib/multiplayer/MultiplayerClient.ts` that defines typed payloads (including `PhysicsUpdatePayload`), a message queue, auto-reconnect, `connect`/`disconnect`, and an `on`/`off` event API, and tracks `playerId`/`roomId` from server `connected`/`joined` messages.
- Implemented queue flushing on open, buffered sending while disconnected, and a `manuallyDisconnected` flag to avoid reconnect after an explicit `disconnect`.
- Extended `useUserStore` (`app/Controllers/Users/useUserStore.tsx`) to hold `multiplayerClient` in Zustand state and added `setMultiplayerClient`, `connectMultiplayer`, and `disconnectMultiplayer` helpers so components can acquire/reuse the client via the existing store.
- Kept payload typing compatible with the server message names used by the project (e.g. `physics:update`, `room:update`, `pregame:tick`, etc.).

### Testing
- Ran `npx eslint app/Lib/multiplayer/MultiplayerClient.ts app/Controllers/Users/useUserStore.tsx`, which failed due to missing local dev dependency `@eslint/eslintrc` in this environment.
- Ran `npx tsc --noEmit`, which failed due to missing type definitions for `react`/`react-dom` in this environment.
- The changes were committed locally with the message `Add multiplayer websocket client and user store integration` and are ready for CI/Developer validation in a full Node/Dev environment where lint/type deps are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950668262c8333a43352e6525ed115)