### PR TITLE
harden api routes

### DIFF
--- a/app/api/Utils/response.ts
+++ b/app/api/Utils/response.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+export type ApiSuccess<T> = {
+  success: true;
+  data: T;
+  error: null;
+};
+
+export type ApiFailure = {
+  success: false;
+  data: null;
+  error: string;
+};
+
+export type ApiResponse<T> = ApiSuccess<T> | ApiFailure;
+
+export function ok<T>(data: T, status = 200) {
+  return NextResponse.json<ApiResponse<T>>(
+    {
+      success: true,
+      data,
+      error: null,
+    },
+    { status },
+  );
+}
+
+export function fail(error: string, status = 400) {
+  return NextResponse.json<ApiResponse<never>>(
+    {
+      success: false,
+      data: null,
+      error,
+    },
+    { status },
+  );
+}

--- a/app/api/Utils/schemas.ts
+++ b/app/api/Utils/schemas.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import { nonEmptyStringSchema } from './validation';
+
+export const createUserBodySchema = z
+  .object({
+    email: z.string().email(),
+    password: nonEmptyStringSchema,
+    name: nonEmptyStringSchema.optional(),
+    firstName: nonEmptyStringSchema,
+    lastName: nonEmptyStringSchema,
+  })
+  .passthrough();
+
+export const updateUserBodySchema = z
+  .object({
+    email: z.string().email().optional(),
+    displayName: nonEmptyStringSchema.optional(),
+  })
+  .passthrough()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required for update.',
+  });
+
+export const createRecordBodySchema = z
+  .object({
+    userId: nonEmptyStringSchema,
+    trackId: nonEmptyStringSchema,
+    totalTime: z.number().finite(),
+    lapTimes: z.array(z.number().finite()).min(1),
+  })
+  .passthrough();
+
+export const updateRecordBodySchema = z
+  .object({
+    userId: nonEmptyStringSchema.optional(),
+    trackId: nonEmptyStringSchema.optional(),
+    totalTime: z.number().finite().optional(),
+    lapTimes: z.array(z.number().finite()).min(1).optional(),
+  })
+  .passthrough()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required for update.',
+  });
+
+export const createSessionBodySchema = z.object({
+  idToken: nonEmptyStringSchema,
+});

--- a/app/api/Utils/user.ts
+++ b/app/api/Utils/user.ts
@@ -1,6 +1,7 @@
 // lib/getUserFromRequest.ts
 import { NextRequest } from 'next/server';
 import { adminAuth, adminAppCheck } from '@/Lib/Firebase/FirebaseAdmin';
+import { fail, ok } from './response';
 
 export async function getUserFromRequest(req: NextRequest) {
   const token = req.cookies.get('firebase_token')?.value;
@@ -13,17 +14,31 @@ export async function getUserFromRequest(req: NextRequest) {
     return null;
   }
 }
-// lib/jsonResponse.ts
-import { NextResponse } from 'next/server';
-import type { User } from '@/Constants/types';
 
-export function jsonResponse(
-  success: boolean,
-  data: User | null,
-  error: string | null = null,
-  status = 200,
-) {
-  return NextResponse.json({ success, data, error }, { status });
+export const jsonResponse = (success: boolean, data: unknown, error: string | null, status = 200) =>
+  success ? ok(data, status) : fail(error ?? 'Unknown error', status);
+
+type FirebaseErrorLike = {
+  code?: string;
+  message?: string;
+};
+
+export function getErrorCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as FirebaseErrorLike).code;
+    if (typeof code === 'string' && code.length > 0) return code;
+  }
+
+  return undefined;
+}
+
+export function getErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as FirebaseErrorLike).message;
+    if (typeof message === 'string' && message.length > 0) return message;
+  }
+
+  return undefined;
 }
 
 // AuthHelpers.ts

--- a/app/api/Utils/validation.ts
+++ b/app/api/Utils/validation.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server';
+import { z, ZodError, type ZodType } from 'zod';
+import { fail } from './response';
+
+export function formatZodError(error: ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) return 'Invalid request payload.';
+
+  const path = issue.path.length ? `${issue.path.join('.')}: ` : '';
+  return `${path}${issue.message}`;
+}
+
+export async function parseJsonBody<T>(
+  req: NextRequest,
+  schema: ZodType<T>,
+): Promise<{ success: true; data: T } | { success: false; response: Response }> {
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return { success: false, response: fail('Invalid JSON body.', 400) };
+  }
+
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    return { success: false, response: fail(formatZodError(parsed.error), 400) };
+  }
+
+  return { success: true, data: parsed.data };
+}
+
+export const nonEmptyStringSchema = z.string().trim().min(1);

--- a/app/api/records/route.ts
+++ b/app/api/records/route.ts
@@ -1,29 +1,34 @@
-// app/api/records/route.ts
-import { NextResponse, NextRequest } from 'next/server';
-import { db } from '@/Lib/Firebase/FirebaseAdmin';
+import { NextRequest } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
+import { db } from '@/Lib/Firebase/FirebaseAdmin';
+import { createRecordBodySchema, updateRecordBodySchema } from '../Utils/schemas';
+import { fail, ok } from '../Utils/response';
+import { nonEmptyStringSchema, parseJsonBody } from '../Utils/validation';
+import { getErrorMessage } from '../Utils/user';
 
-/**
- * Handle POST request to create a new record.
- * @route POST /api/records
- * @returns A JSON response with the created record's ID or an error message.
- */
+type RecordMutationResponse = { message: string; recordId?: string };
+type RecordData = { id: string; [key: string]: unknown };
+
+function parseRecordId(req: NextRequest): string | null {
+  const idResult = nonEmptyStringSchema.safeParse(req.nextUrl.searchParams.get('id'));
+  if (!idResult.success) return null;
+  return idResult.data;
+}
+
+function normalizeError(error: unknown): string {
+  return getErrorMessage(error) ?? 'Internal server error';
+}
+
 export async function POST(req: NextRequest) {
   if (!db) {
-    return NextResponse.json({ error: 'Firebase Admin SDK not initialized.' }, { status: 500 });
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
-    const { userId, trackId, totalTime, lapTimes, ...rest } = await req.json();
+    const body = await parseJsonBody(req, createRecordBodySchema);
+    if (!body.success) return body.response;
 
-    if (!userId || !trackId || totalTime === undefined || !lapTimes) {
-      return NextResponse.json(
-        { error: 'userId, trackId, totalTime, and lapTimes are required.' },
-        { status: 400 },
-      );
-    }
-
-    // Add the record to the 'records' collection.
+    const { userId, trackId, totalTime, lapTimes, ...rest } = body.data;
     const newRecordRef = await db.collection('records').add({
       userId,
       trackId,
@@ -33,29 +38,19 @@ export async function POST(req: NextRequest) {
       ...rest,
     });
 
-    return NextResponse.json(
-      {
-        message: 'Record created successfully',
-        recordId: newRecordRef.id,
-      },
-      { status: 201 },
+    return ok<RecordMutationResponse>(
+      { message: 'Record created successfully', recordId: newRecordRef.id },
+      201,
     );
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error in POST /api/records:', error);
-    return NextResponse.json({ error: error.message || 'Internal server error' }, { status: 500 });
+    return fail(normalizeError(error), 500);
   }
 }
 
-/**
- * Handle GET request to retrieve records.
- * @route GET /api/records?userId=<userId>&trackId=<trackId>
- * @returns A JSON response with a list of records or an error message.
- */
 export async function GET(req: NextRequest) {
   if (!db) {
-    return NextResponse.json({ error: 'Firebase Admin SDK not initialized.' }, { status: 500 });
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
@@ -64,87 +59,57 @@ export async function GET(req: NextRequest) {
 
     let query: FirebaseFirestore.Query = db.collection('records');
 
-    if (userId) {
-      query = query.where('userId', '==', userId);
-    }
-
-    if (trackId) {
-      query = query.where('trackId', '==', trackId);
-    }
-
-    // You can also add sorting and limits if needed:
-    // query = query.orderBy("totalTime", "asc");
+    if (userId) query = query.where('userId', '==', userId);
+    if (trackId) query = query.where('trackId', '==', trackId);
 
     const recordsSnapshot = await query.get();
-
-    const records = recordsSnapshot.docs.map((doc) => ({
+    const records: RecordData[] = recordsSnapshot.docs.map((doc) => ({
       id: doc.id,
       ...doc.data(),
     }));
 
-    return NextResponse.json(records, { status: 200 });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<RecordData[]>(records, 200);
+  } catch (error: unknown) {
     console.error('Error in GET /api/records:', error);
-    return NextResponse.json({ error: error.message || 'Internal server error' }, { status: 500 });
+    return fail(normalizeError(error), 500);
   }
 }
 
-/**
- * Handle PUT request to update an existing record.
- * @route PUT /api/records?id=<recordId>
- * @returns A JSON response confirming the update or an error message.
- */
 export async function PUT(req: NextRequest) {
   if (!db) {
-    return NextResponse.json({ error: 'Firebase Admin SDK not initialized.' }, { status: 500 });
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
-    const recordId = req.nextUrl.searchParams.get('id');
+    const recordId = parseRecordId(req);
+    if (!recordId) return fail('A record ID is required.', 400);
 
-    if (!recordId) {
-      return NextResponse.json({ error: 'A record ID is required.' }, { status: 400 });
-    }
+    const body = await parseJsonBody(req, updateRecordBodySchema);
+    if (!body.success) return body.response;
 
-    const updates = await req.json();
+    await db.collection('records').doc(recordId).set(body.data, { merge: true });
 
-    await db.collection('records').doc(recordId).set(updates, { merge: true });
-
-    return NextResponse.json({ message: 'Record updated successfully' }, { status: 200 });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<RecordMutationResponse>({ message: 'Record updated successfully' }, 200);
+  } catch (error: unknown) {
     console.error('Error in PUT /api/records:', error);
-    return NextResponse.json({ error: error.message || 'Internal server error' }, { status: 500 });
+    return fail(normalizeError(error), 500);
   }
 }
 
-/**
- * Handle DELETE request to remove a record.
- * @route DELETE /api/records?id=<recordId>
- * @returns A JSON response confirming deletion or an error message.
- */
 export async function DELETE(req: NextRequest) {
   if (!db) {
-    return NextResponse.json({ error: 'Firebase Admin SDK not initialized.' }, { status: 500 });
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
-    const recordId = req.nextUrl.searchParams.get('id');
-
-    if (!recordId) {
-      return NextResponse.json({ error: 'A record ID is required.' }, { status: 400 });
-    }
+    const recordId = parseRecordId(req);
+    if (!recordId) return fail('A record ID is required.', 400);
 
     await db.collection('records').doc(recordId).delete();
 
-    return NextResponse.json({ message: 'Record deleted successfully' }, { status: 200 });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<RecordMutationResponse>({ message: 'Record deleted successfully' }, 200);
+  } catch (error: unknown) {
     console.error('Error in DELETE /api/records:', error);
-    return NextResponse.json({ error: error.message || 'Internal server error' }, { status: 500 });
+    return fail(normalizeError(error), 500);
   }
 }

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,34 +1,42 @@
-// app/api/session/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
 import { adminAuth } from '@/Lib/Firebase/FirebaseAdmin';
+import { createSessionBodySchema } from '../Utils/schemas';
+import { fail, ok } from '../Utils/response';
+import { parseJsonBody } from '../Utils/validation';
+
+type SessionCreateResponse = {
+  uid: string;
+  email?: string;
+};
+
+type SessionDeleteResponse = {
+  message: string;
+};
 
 export async function POST(req: NextRequest) {
-  // Login: set ID token in HTTP-only cookie
-  const { idToken } = await req.json();
+  const body = await parseJsonBody(req, createSessionBodySchema);
+  if (!body.success) return body.response;
 
   try {
-    const decoded = await adminAuth.verifyIdToken(idToken);
-    const res = NextResponse.json({ uid: decoded.uid, email: decoded.email });
-    // Set secure HTTP-only cookie
+    const decoded = await adminAuth.verifyIdToken(body.data.idToken);
+    const res = ok<SessionCreateResponse>({ uid: decoded.uid, email: decoded.email }, 200);
+
     res.cookies.set({
       name: 'firebase_token',
-      value: idToken,
+      value: body.data.idToken,
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       path: '/',
-      maxAge: 60 * 60 * 24, // 1 day
+      maxAge: 60 * 60 * 24,
     });
     return res;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (err) {
-    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  } catch {
+    return fail('Invalid token', 401);
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function DELETE(req: NextRequest) {
-  // Logout: remove cookie
-  const res = NextResponse.json({ message: 'Logged out' });
+export async function DELETE() {
+  const res = ok<SessionDeleteResponse>({ message: 'Logged out' }, 200);
   res.cookies.set({
     name: 'firebase_token',
     value: '',

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,139 +1,132 @@
-// app/api/users/route.ts
 import { NextRequest } from 'next/server';
-import { adminAuth, db } from '@/Lib/Firebase/FirebaseAdmin';
 import { FieldValue } from 'firebase-admin/firestore';
-import { User } from '@/Constants/types';
-import { jsonResponse, getFirebaseErrorMessage, verifyRequest } from '../Utils/user';
+import { adminAuth, db } from '@/Lib/Firebase/FirebaseAdmin';
 import { validatePassword } from '@/Components/UI/Auth/AuthHelpers';
+import { createUserBodySchema, updateUserBodySchema } from '../Utils/schemas';
+import { fail, ok } from '../Utils/response';
+import { nonEmptyStringSchema, parseJsonBody } from '../Utils/validation';
+import {
+  getErrorCode,
+  getErrorMessage,
+  getFirebaseErrorMessage,
+  verifyRequest,
+} from '../Utils/user';
 
-// POST /api/users
+type UserMutationResponse = { uid: string };
+type UserReadResponse = { uid: string; [key: string]: unknown };
+
+function parseUid(req: NextRequest): string | null {
+  const uidResult = nonEmptyStringSchema.safeParse(req.nextUrl.searchParams.get('uid'));
+  if (!uidResult.success) return null;
+  return uidResult.data;
+}
+
+function mapFirebaseError(error: unknown, fallback: string) {
+  const code = getErrorCode(error);
+  if (code) return getFirebaseErrorMessage(code);
+
+  const message = getErrorMessage(error);
+  if (message) return getFirebaseErrorMessage(message);
+
+  return fallback;
+}
+
 // POST /api/users
 export async function POST(req: NextRequest) {
   if (!adminAuth || !db) {
-    return jsonResponse(false, null, 'Firebase Admin SDK not initialized.', 500);
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
     await verifyRequest(req);
-    const { email, password, name, firstName, lastName, ...rest } = await req.json();
+    const body = await parseJsonBody(req, createUserBodySchema);
+    if (!body.success) return body.response;
 
-    if (!email || !password || !firstName || !lastName) {
-      return jsonResponse(false, null, 'Email, password and name fields are required', 400);
-    }
-
-    // enforce password rules
+    const { email, password, name, ...rest } = body.data;
     const passwordError = validatePassword(password);
-    if (passwordError) {
-      return jsonResponse(false, null, passwordError, 400);
-    }
+    if (passwordError) return fail(passwordError, 400);
 
-    // Create Firebase Auth account
     const authUser = await adminAuth.createUser({
       email,
       password,
-      displayName: name || null,
+      displayName: name ?? null,
     });
 
-    // Create Firestore document
-    await db
-      .collection('users')
-      .doc(authUser.uid)
-      .set({
-        email,
-        displayName: name || null,
-        createdAt: FieldValue.serverTimestamp(),
-        ...rest,
-      });
+    await db.collection('users').doc(authUser.uid).set({
+      email,
+      displayName: name ?? null,
+      createdAt: FieldValue.serverTimestamp(),
+      ...rest,
+    });
 
-    return jsonResponse(true, { uid: authUser.uid }, null, 201);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<UserMutationResponse>({ uid: authUser.uid }, 201);
+  } catch (error: unknown) {
     console.error('Error in POST /api/users:', error);
-    if (error.code === 'auth/email-already-exists') {
-      return jsonResponse(false, null, 'Email already in use.', 409);
+    if (getErrorCode(error) === 'auth/email-already-exists') {
+      return fail('Email already in use.', 409);
     }
-    return jsonResponse(
-      false,
-      null,
-      getFirebaseErrorMessage(error.message) || 'Internal server error',
-      500,
-    );
+    return fail(mapFirebaseError(error, 'Internal server error'), 500);
   }
 }
 
 // GET /api/users?uid=<uid>
 export async function GET(req: NextRequest) {
   if (!db) {
-    return jsonResponse(false, null, 'Firebase Admin SDK not initialized.', 500);
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
     await verifyRequest(req);
-    const uid = req.nextUrl.searchParams.get('uid');
-    if (!uid) {
-      return jsonResponse(false, null, 'A user ID (uid) is required', 400);
-    }
+    const uid = parseUid(req);
+    if (!uid) return fail('A user ID (uid) is required', 400);
 
     const userDoc = await db.collection('users').doc(uid).get();
-    if (!userDoc.exists) {
-      return jsonResponse(false, null, 'User not found', 404);
-    }
+    if (!userDoc.exists) return fail('User not found', 404);
 
-    return jsonResponse(true, { uid, ...userDoc.data() }, null, 200);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<UserReadResponse>({ uid, ...(userDoc.data() ?? {}) }, 200);
+  } catch (error: unknown) {
     console.error('Error in GET /api/users:', error);
-    return jsonResponse(
-      false,
-      null,
-      getFirebaseErrorMessage(error.message) || 'Internal server error',
-      500,
-    );
+    return fail(mapFirebaseError(error, 'Internal server error'), 500);
   }
 }
 
 // PUT /api/users?uid=<uid>
 export async function PUT(req: NextRequest) {
   if (!adminAuth || !db) {
-    return jsonResponse(false, null, 'Firebase Admin SDK not initialized.', 500);
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
     await verifyRequest(req);
-    const uid = req.nextUrl.searchParams.get('uid');
-    if (!uid) {
-      return jsonResponse(false, null, 'A user ID (uid) is required', 400);
-    }
+    const uid = parseUid(req);
+    if (!uid) return fail('A user ID (uid) is required', 400);
 
-    const { email, displayName, ...rest } = await req.json();
+    const body = await parseJsonBody(req, updateUserBodySchema);
+    if (!body.success) return body.response;
 
-    // --- Email uniqueness check ---
+    const { email, displayName, ...rest } = body.data;
+
     if (email) {
       const snapshot = await db.collection('users').where('email', '==', email).get();
       const conflict = snapshot.docs.some((doc) => doc.id !== uid);
-      if (conflict) {
-        return jsonResponse(false, null, 'Email already in use.', 409);
-      }
+      if (conflict) return fail('Email already in use.', 409);
     }
 
-    // --- Update Firebase Auth ---
-    const authUpdate: Partial<User> = {};
+    const authUpdate: Record<string, string> = {};
     if (email) authUpdate.email = email;
     if (displayName) authUpdate.displayName = displayName;
 
     if (Object.keys(authUpdate).length > 0) {
       try {
         await adminAuth.updateUser(uid, authUpdate);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if (error.code === 'auth/email-already-exists') {
-          return jsonResponse(false, null, 'Email already in use.', 409);
+      } catch (error: unknown) {
+        if (getErrorCode(error) === 'auth/email-already-exists') {
+          return fail('Email already in use.', 409);
         }
         throw error;
       }
     }
 
-    // --- Merge Firestore updates ---
     const firestoreUpdate: Record<string, unknown> = {};
     if (email) firestoreUpdate.email = email;
     if (displayName) firestoreUpdate.displayName = displayName;
@@ -143,50 +136,32 @@ export async function PUT(req: NextRequest) {
       await db.collection('users').doc(uid).set(firestoreUpdate, { merge: true });
     }
 
-    return jsonResponse(true, { uid }, null, 200);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<UserMutationResponse>({ uid }, 200);
+  } catch (error: unknown) {
     console.error('Error in PUT /api/users:', error);
-    if (error.code === 'auth/user-not-found') {
-      return jsonResponse(false, null, 'User not found', 404);
-    }
-    return jsonResponse(
-      false,
-      null,
-      getFirebaseErrorMessage(error.message) || 'Internal server error',
-      500,
-    );
+    if (getErrorCode(error) === 'auth/user-not-found') return fail('User not found', 404);
+    return fail(mapFirebaseError(error, 'Internal server error'), 500);
   }
 }
 
 // DELETE /api/users?uid=<uid>
 export async function DELETE(req: NextRequest) {
   if (!adminAuth || !db) {
-    return jsonResponse(false, null, 'Firebase Admin SDK not initialized.', 500);
+    return fail('Firebase Admin SDK not initialized.', 500);
   }
 
   try {
     await verifyRequest(req);
-    const uid = req.nextUrl.searchParams.get('uid');
-    if (!uid) {
-      return jsonResponse(false, null, 'A user ID (uid) is required', 400);
-    }
+    const uid = parseUid(req);
+    if (!uid) return fail('A user ID (uid) is required', 400);
 
     await adminAuth.deleteUser(uid);
     await db.collection('users').doc(uid).delete();
 
-    return jsonResponse(true, { uid }, null, 200);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
+    return ok<UserMutationResponse>({ uid }, 200);
+  } catch (error: unknown) {
     console.error('Error in DELETE /api/users:', error);
-    if (error.code === 'auth/user-not-found') {
-      return jsonResponse(false, null, 'User not found', 404);
-    }
-    return jsonResponse(
-      false,
-      null,
-      getFirebaseErrorMessage(error.message) || 'Internal server error',
-      500,
-    );
+    if (getErrorCode(error) === 'auth/user-not-found') return fail('User not found', 404);
+    return fail(mapFirebaseError(error, 'Internal server error'), 500);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "firebase": "^12.1.0",
         "firebase-admin": "^13.4.0",
         "leva": "^0.10.0",
-        "next": "15.3.5",
+        "next": "15.5.7",
         "postprocessing": "^6.37.6",
         "react": "^19.0.0",
         "react-device-detect": "^2.2.3",
@@ -33,6 +33,7 @@
         "three-mesh-bvh": "^0.9.1",
         "three-stdlib": "^2.36.0",
         "ws": "^8.18.3",
+        "zod": "^4.3.6",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -44,7 +45,7 @@
         "@types/react-dom": "^19.1.6",
         "@types/ws": "^8.18.1",
         "eslint": "^9",
-        "eslint-config-next": "15.3.5",
+        "eslint-config-next": "15.5.7",
         "eslint-import-resolver-typescript": "^4.4.4",
         "glslify": "^7.1.1",
         "prettier": "^3.6.2",
@@ -1685,15 +1686,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
-      "integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
+      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.5.tgz",
-      "integrity": "sha512-BZwWPGfp9po/rAnJcwUBaM+yT/+yTWIkWdyDwc74G9jcfTrNrmsHe+hXHljV066YNdVs8cxROxX5IgMQGX190w==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.7.tgz",
+      "integrity": "sha512-DtRU2N7BkGr8r+pExfuWHwMEPX5SD57FeA6pxdgCHODo+b/UgIgjE+rgWKtJAbEbGhVZ2jtHn4g3wNhWFoNBQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1701,9 +1702,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
-      "integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
+      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1717,9 +1718,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
-      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
+      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
       "cpu": [
         "x64"
       ],
@@ -1733,9 +1734,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
-      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
+      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
       "cpu": [
         "arm64"
       ],
@@ -1749,9 +1750,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
-      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
+      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
       "cpu": [
         "arm64"
       ],
@@ -1765,9 +1766,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
-      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
+      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
       "cpu": [
         "x64"
       ],
@@ -1781,9 +1782,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
-      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
+      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
       "cpu": [
         "x64"
       ],
@@ -1797,9 +1798,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
-      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
+      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1813,9 +1814,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
-      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
+      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
       "cpu": [
         "x64"
       ],
@@ -2451,12 +2452,6 @@
       "peerDependencies": {
         "react": ">= 16.3.0"
       }
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -4467,17 +4462,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5407,13 +5391,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.5.tgz",
-      "integrity": "sha512-oQdvnIgP68wh2RlR3MdQpvaJ94R6qEFl+lnu8ZKxPj5fsAHrSF/HlAOZcsimLw3DT6bnEQIUdbZC2Ab6sWyptg==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.7.tgz",
+      "integrity": "sha512-nU/TRGHHeG81NeLW5DeQT5t6BDUqbpsNQTvef1ld/tqHT+/zTx60/TIhKnmPISTTe++DVo+DLxDmk4rnwHaZVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.3.5",
+        "@next/eslint-plugin-next": "15.5.7",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -8970,15 +8954,14 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "15.3.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
-      "integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
+      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.5",
-        "@swc/counter": "0.1.3",
+        "@next/env": "15.5.7",
         "@swc/helpers": "0.5.15",
-        "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -8990,19 +8973,19 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.5",
-        "@next/swc-darwin-x64": "15.3.5",
-        "@next/swc-linux-arm64-gnu": "15.3.5",
-        "@next/swc-linux-arm64-musl": "15.3.5",
-        "@next/swc-linux-x64-gnu": "15.3.5",
-        "@next/swc-linux-x64-musl": "15.3.5",
-        "@next/swc-win32-arm64-msvc": "15.3.5",
-        "@next/swc-win32-x64-msvc": "15.3.5",
-        "sharp": "^0.34.1"
+        "@next/swc-darwin-arm64": "15.5.7",
+        "@next/swc-darwin-x64": "15.5.7",
+        "@next/swc-linux-arm64-gnu": "15.5.7",
+        "@next/swc-linux-arm64-musl": "15.5.7",
+        "@next/swc-linux-x64-gnu": "15.5.7",
+        "@next/swc-linux-x64-musl": "15.5.7",
+        "@next/swc-win32-arm64-msvc": "15.5.7",
+        "@next/swc-win32-x64-msvc": "15.5.7",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
+        "@playwright/test": "^1.51.1",
         "babel-plugin-react-compiler": "*",
         "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -10461,14 +10444,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -11830,6 +11805,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "three-mesh-bvh": "^0.9.1",
     "three-stdlib": "^2.36.0",
     "ws": "^8.18.3",
+    "zod": "^4.3.6",
     "zustand": "^5.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Implemented a client-side API hardening pass with shared validation and typed contracts.

What I changed
Added typed API response contract helpers:

response.ts
Introduces ApiResponse<T>, ok(...), and fail(...) for consistent handler responses.
Added shared Zod validation utilities:

validation.ts
Introduces parseJsonBody(...), formatZodError(...), and nonEmptyStringSchema.
Added shared request schemas:

schemas.ts
Schemas for:
user create/update payloads
record create/update payloads
session create payload
Refactored user API route to use shared schemas + typed error handling (unknown instead of any):

route.ts
Validates body/query params, centralizes Firebase error mapping, removes repeated any catch patterns.
Refactored records API route similarly:

route.ts
Validates create/update payloads and required id query param.
Refactored session API route similarly:

route.ts
Validates idToken with schema and uses typed response helpers.
Improved utility error helpers:

user.ts
Added getErrorCode(...) and getErrorMessage(...) for safer unknown error handling.
Added dependency:

package.json + package-lock.json
zod